### PR TITLE
Use hasPermission() in mayUpdateLibrary()

### DIFF
--- a/Core/H5PSymfony.php
+++ b/Core/H5PSymfony.php
@@ -301,7 +301,7 @@ class H5PSymfony implements \H5PFrameworkInterface
      */
     public function mayUpdateLibraries()
     {
-        return $this->authorizationChecker->isGranted('ROLE_UPDATE_H5P_LIBRARIES');
+        return $this->hasPermission(\H5PPermission::UPDATE_LIBRARIES);
     }
 
     /**
@@ -866,7 +866,7 @@ class H5PSymfony implements \H5PFrameworkInterface
     /**
      * Implements hasPermission
      *
-     * @param H5PPermission $permission
+     * @param int $permission
      * @param int $content_id
      * @return bool
      */


### PR DESCRIPTION
It avoid mistakes in permissions names
(ROLE_H5P_UPDATE_LIBRARIES != ROLE_UPDATE_H5P_LIBRARIES)

I also correct the PHPDoc param of hasPermission